### PR TITLE
Update to Mojang API

### DIFF
--- a/class.verifymcuser.plugin.php
+++ b/class.verifymcuser.plugin.php
@@ -16,7 +16,7 @@
 $PluginInfo['VerifyMCUser'] = array(
 	'Name' => 'Verify Minecraft Username',
 	'Description' => 'Verifies usernames are premium minecraft usernames during registration. A special thanks to gabessdsp at vanillaforums.org for sponsoring this plugin.',
-	'Version' => '1.2',
+	'Version' => '1.3',
 	'RequiredApplications' => array('Vanilla' => '2.0.18.8'),
 	'RequiredTheme' => FALSE,
 	'RequiredPlugins' => FALSE,
@@ -42,7 +42,7 @@ class VerifyMCUser extends Gdn_Plugin {
 	
 	public function PluginController_VerifyMCUser_Create($Sender) {
       $Username = filter_var($Sender->RequestArgs[0], FILTER_SANITIZE_ENCODED);
-      echo file_get_contents('http://minecraft.net/haspaid.jsp?user=' . $Username);
+      echo empty(file_get_contents('https://api.mojang.com/users/profiles/minecraft/' . $Username)) ? false : true;
 	}
 	
     public function EntryController_Register_Handler($Sender) {
@@ -52,7 +52,7 @@ class VerifyMCUser extends Gdn_Plugin {
     public function EntryController_RegisterValidation_Handler($Sender) {
       $FormValues = $Sender->Form->FormValues();
       $Username = $FormValues['Name'];
-      if(file_get_contents('http://minecraft.net/haspaid.jsp?user=' . $Username) == 'false') {
+      if(empty(file_get_contents('https://api.mojang.com/users/profiles/minecraft/' . $Username))) {
         $Sender->Form->AddError('Please enter a valid Minecraft username.');
         $Sender->Render();
         exit();


### PR DESCRIPTION
minecraft.net/haspaid.jsp has been removed, the alternative is to use the mojang api.

The endpoint is blank when an invalid username is supplied, otherwise it returns some json (the UUID and the playername again).

Ideally the uuid should be stored but ehhhh.

Not entirely sure if premium accounts are even still a thing, but I'm not too bothered by it. If there is still that free/paid differentiation I would assume that this would fail and let free users register.

I also assumed that the original response for the old minecraft api endpoint for haspaid was only true or false. Can't really check.

Also took the liberty of bumping the version?